### PR TITLE
Add favicon and .eot font to package

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.0.2] - 2016-11-09
+~~~~~~~~~~~~~~~~~~~~
+
+* Added favicon and .eot font file to distributed package
+
 [1.0.1] - 2016-10-14
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include CHANGELOG.rst
 include CONTRIBUTING.rst
 include LICENSE.txt
 include README.rst
-recursive-include edx_theme *.conf *.html *.png *.gif *.js *.css *.jpg *.jpeg *.svg *.ttf *.woff *.py
+recursive-include edx_theme *.conf *.html *.png *.gif *.ico *.js *.css *.jpg *.jpeg *.eot *.svg *.ttf *.woff *.py

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ requirements: ## install development environment requirements
 	pip-sync requirements/base.txt requirements/dev.txt requirements/private.* requirements/test.txt
 
 test: clean ## run tests in the current virtualenv
-	py.test --cov edx_them
+	py.test --cov edx_theme
 
 test-all: ## run tests on every supported Python/Sphinx combination
 	tox -e quality

--- a/README.rst
+++ b/README.rst
@@ -1,10 +1,29 @@
-edx-sphinx-theme  |Travis|_ |Codecov|_
-======================================
-.. |Travis| image:: https://travis-ci.org/edx/edx-sphinx-theme.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/edx-sphinx-theme
+edx-sphinx-theme
+================
 
-.. |Codecov| image:: http://codecov.io/github/edx/edx-sphinx-theme/coverage.svg?branch=master
-.. _Codecov: http://codecov.io/github/edx/edx-sphinx-theme?branch=master
+.. image:: https://img.shields.io/pypi/v/edx-sphinx-theme.svg
+    :target: https://pypi.python.org/pypi/edx-sphinx-theme/
+    :alt: PyPI
+
+.. image:: https://travis-ci.org/edx/edx-sphinx-theme.svg?branch=master
+    :target: https://travis-ci.org/edx/edx-sphinx-theme
+    :alt: Travis
+
+.. image:: http://codecov.io/github/edx/edx-sphinx-theme/coverage.svg?branch=master
+    :target: http://codecov.io/github/edx/edx-sphinx-theme?branch=master
+    :alt: Codecov
+
+.. image:: http://edx-sphinx-theme.readthedocs.io/en/latest/?badge=latest
+    :target: http://edx-sphinx-theme.readthedocs.io/en/latest/
+    :alt: Documentation
+
+.. image:: https://img.shields.io/pypi/pyversions/edx-sphinx-theme.svg
+    :target: https://pypi.python.org/pypi/edx-sphinx-theme/
+    :alt: Supported Python versions
+
+.. image:: https://img.shields.io/github/license/edx/edx-sphinx-theme.svg
+    :target: https://github.com/edx/edx-sphinx-theme/blob/master/LICENSE.txt
+    :alt: License
 
 edx-sphinx-theme is a Sphinx theme for `Open edX`_ documentation.  It should be
 used for all documentation in repositories in the ``edx`` GitHub organization
@@ -51,6 +70,20 @@ For example:
         (master_doc, 'edx-sphinx-theme.tex', 'edx-sphinx-theme Documentation',
          author, 'manual'),
     ]
+
+Read the Docs Configuration
+---------------------------
+
+Because this theme is a Python package which needs to be installed, `Read the
+Docs`_ needs to be configured appropriately to be able to install it when
+performing documentation builds.  Under ``Advanced Settings``:
+
+* ``Install your project inside a virtualenv using setup.py install`` should
+  be checked
+* ``Requirements file`` should point to a pip requirements file which includes
+  ``open-edx-theme``.
+
+.. _Read the Docs: https://readthedocs.org/
 
 Documentation
 -------------

--- a/edx_theme/__init__.py
+++ b/edx_theme/__init__.py
@@ -10,7 +10,7 @@ import six
 from six.moves.urllib.parse import quote
 
 # When you change this, also update the CHANGELOG.rst file, thanks.
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 # Use these constants in the conf.py for Sphinx in your repository
 AUTHOR = 'edX Inc.'


### PR DESCRIPTION
Candidate for a 1.0.2 release; I noticed that the favicon was missing from the package uploaded to PyPI when checking the output for edx-documentation.