### PR TITLE
Enable parallel builds

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,15 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.1.0] - 2017-06-28
+~~~~~~~~~~~~~~~~~~~~
+
+* Supply extension metadata to enable parallel builds.
+
 [1.0.2] - 2016-11-09
 ~~~~~~~~~~~~~~~~~~~~
 
-* Added favicon and .eot font file to distributed package
+* Added favicon and .eot font file to distributed package.
 
 [1.0.1] - 2016-10-14
 ~~~~~~~~~~~~~~~~~~~~

--- a/edx_theme/__init__.py
+++ b/edx_theme/__init__.py
@@ -10,7 +10,7 @@ import six
 from six.moves.urllib.parse import quote
 
 # When you change this, also update the CHANGELOG.rst file, thanks.
-__version__ = '1.0.2'
+__version__ = '1.1.0'
 
 # Use these constants in the conf.py for Sphinx in your repository
 AUTHOR = 'edX Inc.'
@@ -47,6 +47,15 @@ def setup(app):
 
     Arguments:
         app (Sphinx): Application object for the Sphinx process
+
+    Returns:
+        a dictionary of metadata (http://www.sphinx-doc.org/en/stable/extdev/#extension-metadata)
     """
     event = 'html-page-context' if six.PY3 else b'html-page-context'
     app.connect(event, update_context)
+
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+        'version': __version__,
+    }


### PR DESCRIPTION
The sphinx -j4 option only reads files in parallel if the extension allows it.  This metadata is how we can allow it.