### PR TITLE
Add navigation_depth theme option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,11 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.3.0] - 2017-10-13
+~~~~~~~~~~~~~~~~~~~~
+
+* Added support for the ``navigation_depth`` theme option.
+
 [1.2.0] - 2017-07-18
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_theme/__init__.py
+++ b/edx_theme/__init__.py
@@ -10,7 +10,7 @@ import six
 from six.moves.urllib.parse import quote
 
 # When you change this, also update the CHANGELOG.rst file, thanks.
-__version__ = '1.2.0'
+__version__ = '1.3.0'
 
 # Use these constants in the conf.py for Sphinx in your repository
 AUTHOR = 'edX Inc.'

--- a/edx_theme/layout.html
+++ b/edx_theme/layout.html
@@ -101,7 +101,7 @@
       </div>
 
       <div class="wy-menu wy-menu-vertical" data-spy="affix">
-        {% set toctree = toctree(maxdepth=2, collapse=False) %}
+        {% set toctree = toctree(maxdepth=theme_navigation_depth|int, collapse=False) %}
         {% if toctree %}
             {{ toctree }}
         {% else %}

--- a/edx_theme/theme.conf
+++ b/edx_theme/theme.conf
@@ -5,3 +5,4 @@ stylesheet = css/theme.css
 [options]
 typekit_id = hiw1hhg
 analytics_id = 
+navigation_depth = 2


### PR DESCRIPTION
Sylvia asked that we be able to make the left-hand nav bar have entries down to three levels. This adds support for the option, defaulted to 2.