### PR TITLE
Add theme option includehidden.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,12 @@ Change Log
 Unreleased
 ~~~~~~~~~~
 
+[1.4.0] - 2018-12-04
+~~~~~~~~~~~~~~~~~~~~
+
+* Added support for the ``includehidden`` theme option. This shows a hidden toc
+  in sidebar.
+
 * Upgraded many dependencies.
 
 [1.3.0] - 2017-10-13

--- a/edx_theme/layout.html
+++ b/edx_theme/layout.html
@@ -101,7 +101,7 @@
       </div>
 
       <div class="wy-menu wy-menu-vertical" data-spy="affix">
-        {% set toctree = toctree(maxdepth=theme_navigation_depth|int, collapse=False) %}
+        {% set toctree = toctree(maxdepth=theme_navigation_depth|int, includehidden=theme_includehidden|tobool, collapse=False) %}
         {% if toctree %}
             {{ toctree }}
         {% else %}

--- a/edx_theme/theme.conf
+++ b/edx_theme/theme.conf
@@ -6,3 +6,4 @@ stylesheet = css/theme.css
 typekit_id = hiw1hhg
 analytics_id = 
 navigation_depth = 2
+includehidden = False


### PR DESCRIPTION
The theme option `includehidden` allows you to show a hidden toc
in the sidebar.

This is to enable the use case where the toc is hidden because the index page is custom, but you still want the toc to appear in the sidebar.  See this PR as an example: https://github.com/edx/edx-developer-docs/pull/10