### PR TITLE
 feat: add "Edit on Github" button in breadcrumbs 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,13 @@ Change Log
 
 .. There should always be an "Unreleased" section for changes pending release.
 
+[2.1.0] - 2021-04-01
+~~~~~~~~~~~~~~~~~~~~
+
+* Adding "Edit on Github" button to breadcrums.
+
+  This should make it easier for viewers to easily correct or update bad documentation.
+
 [2.0.0] - 2021-01-28
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/edx_theme/__init__.py
+++ b/edx_theme/__init__.py
@@ -11,7 +11,7 @@ import six
 from six.moves.urllib.parse import quote  # pylint: disable=wrong-import-order
 
 # When you change this, also update the CHANGELOG.rst file, thanks.
-__version__ = '2.0.0'
+__version__ = '2.1.0'
 
 # Use these constants in the conf.py for Sphinx in your repository
 AUTHOR = 'edX Inc.'

--- a/edx_theme/breadcrumbs.html
+++ b/edx_theme/breadcrumbs.html
@@ -6,6 +6,14 @@
       <a href="{{ help_url }}" target="_blank">{{ help_link_text|default('Get Help', true) }}</a> or
     {%- endif -%}
     <a href="{{ feedback_form_url }}" target="_blank">{{ feedback_form_link_text|default('Give Doc Feedback', true) }}</a>
+    {%- if display_github %}
+        {%- if check_meta and 'github_url' in meta %}
+        <!-- User defined GitHub URL -->
+        <a href="{{ meta['github_url'] }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+        {%- else %}
+        <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode or "blob" }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ page_source_suffix }}" class="fa fa-github"> {{ _('Edit on GitHub') }}</a>
+        {%- endif %}
+    {%- endif %}
   </li>
 </ul>
 <hr/>


### PR DESCRIPTION
Currently, viewers of documentation would need to know alot about a page
to know where they need to go to fix outdated docs. "Edit on Github"
button should decrease the barrier in entry for improving docs.