### PR TITLE
docs: Adding docs on 'Edit on Github' page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,8 @@ To use edx-sphinx-theme for a repository's documentation:
 * Use the ``AUTHOR`` constant where appropriate in conf.py
   (this default is only provided as a convenience; the repository is free
   to use another value if appropriate).
+* To add an "Edit on Github" link to every page, add a dict called ``html_context``,
+  as detailed in the following example.
 
 For example:
 
@@ -73,6 +75,14 @@ For example:
         (master_doc, 'edx-sphinx-theme.tex', 'edx-sphinx-theme Documentation',
          author, 'manual'),
     ]
+
+    html_context = {
+        "display_github": True, # Integrate GitHub
+        "github_user": "edx", # Username
+        "github_repo": 'edx-sphinx-theme', # Repo name
+        "github_version": "master", # Version
+        "conf_py_path": "/docs/", # Path in the checkout to the docs root
+    }
 
 Read the Docs Configuration
 ---------------------------

--- a/README.rst
+++ b/README.rst
@@ -42,18 +42,13 @@ This theme makes the following changes to the default Sphinx output:
 
 To use edx-sphinx-theme for a repository's documentation:
 
-* ``pip install edx-sphinx-theme`` or equivalent (add ``edx-sphinx-theme``
-  to any appropriate requirements files)
-* Add ``edx_theme`` to the ``extensions`` list in conf.py (it adds the
-  feedback form URL to the rendering context for each page).
-* Update the ``html_theme`` and ``html_theme_path`` values in conf.py so the
-  theme can be located and loaded.
+* ``pip install edx-sphinx-theme`` or equivalent (add ``edx-sphinx-theme`` to any appropriate requirements files)
+* Add ``edx_theme`` to the ``extensions`` list in conf.py (it adds the feedback form URL to the rendering context for each page).
+* Update the ``html_theme`` and ``html_theme_path`` values in conf.py so the theme can be located and loaded.
 * Set ``html_favicon`` to the path of the favicon.ico file in the theme.
 * Use the ``AUTHOR`` constant where appropriate in conf.py
-  (this default is only provided as a convenience; the repository is free
-  to use another value if appropriate).
-* To add an "Edit on Github" link to every page, add a dict called ``html_context``,
-  as detailed in the following example.
+  (This default is only provided as a convenience. The repository is free to use another value if appropriate).
+* To add an "Edit on Github" link to every page, add a dict called ``html_context``, as detailed in the following example.
 
 For example:
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,31 @@
 envlist = py38-sphinx{11,14},docs,quality
 
 [doc8]
-max-line-length = 120
+; D001 = Line too long
+ignore=D001
 
 [pep8]
 exclude = .git,.tox
 max-line-length = 120
 
 [pydocstyle]
-ignore = D200,D203,D212,D406,D413,D407
+; D101 = Missing docstring in public class
+; D200 = One-line docstring should fit on one line with quotes
+; D203 = 1 blank line required before class docstring
+; D212 = Multi-line docstring summary should start at the first line
+; D215 = Section underline is over-indented (numpy style)
+; D404 = First word of the docstring should not be This (numpy style)
+; D405 = Section name should be properly capitalized (numpy style)
+; D406 = Section name should end with a newline (numpy style)
+; D407 = Missing dashed underline after section (numpy style)
+; D408 = Section underline should be in the line following the section’s name (numpy style)
+; D409 = Section underline should match the length of its name (numpy style)
+; D410 = Missing blank line after section (numpy style)
+; D411 = Missing blank line before section (numpy style)
+; D412 = No blank lines allowed between a section header and its content (numpy style)
+; D413 = Missing blank line after last section (numpy style)
+; D414 = Section has no content (numpy style)
+ignore = D101,D200,D203,D212,D215,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414
 
 [pytest]
 addopts = --cov-report term-missing


### PR DESCRIPTION
This feature was added in https://github.com/edx/edx-sphinx-theme/commit/71cbe6d3b4ca978e7ff54cada6f97691e055d15a